### PR TITLE
Respect `~/.railsrc` file when generating new rails apps

### DIFF
--- a/lib/rails/diff.rb
+++ b/lib/rails/diff.rb
@@ -61,6 +61,16 @@ module Rails
         end
       end
 
+      def railsrc_path
+        "#{ENV["HOME"]}/.railsrc"
+      end
+
+      def railsrc_options
+        return @railsrc_options if defined?(@railsrc_options)
+
+        @railsrc_options = File.read(railsrc_path).tr("\n", " ") if File.exist?(railsrc_path)
+      end
+
       def app_name = @app_name ||= File.basename(Dir.pwd)
 
       def list_files(dir, skip = [])
@@ -159,8 +169,19 @@ module Rails
             system("bundle install >/dev/null 2>&1")
           end
 
+          rails_new_command = "bundle exec rails new #{template_app_path} --main --skip-bundle --force --skip-test --skip-system-test --quiet #{new_app_options}"
+
+          if railsrc_options
+            rails_new_command = "#{rails_new_command} #{railsrc_options}"
+
+            puts "Using default options from #{railsrc_path}:"
+            puts "  > #{railsrc_options}\n\n"
+          end
+
           puts "Generating new Rails application"
-          system("bundle exec rails new #{template_app_path} --main --skip-bundle --force --skip-test --skip-system-test --quiet #{new_app_options}")
+          puts "  > #{rails_new_command}\n\n"
+
+          system(rails_new_command)
         end
       end
 


### PR DESCRIPTION
Hey @MatheusRich, thanks for this cool project!

I just decided to give it a go and noticed I was getting some errors related to mysql when running the CLI:


```
❯ rails-diff file README.md
Checking out Rails (at commit 348f9b1)
Installing Rails dependencies
Generating new Rails application
Could not find mysql2-0.5.6 in locally installed gems
Run `bundle install` to install missing gems.
README.md diff:
===============
README.md not found in the Rails template
```

I don't have mysql installed on my machine, so this could explain why. But since I have the `--database=postgresql` option in my `~/.railsrc` file I usually never get this error when generating new Rails app using the `rails new` command. I thought it might make sense to also generate the app `rails-diff` uses using these options.

So, this pull request adds the ability to let `rails-diff` generate the Rails app it uses using the options defined in `~/.railsrc`:

```
❯ ./exe/rails-diff file README.md
Checking out Rails (at commit 348f9b1)
Installing Rails dependencies

Using default options from /Users/marcoroth/.railsrc:
  > --database=postgresql --javascript=esbuild --css=tailwind

Generating new Rails application
  > bundle exec rails new /Users/marcoroth/.rails-diff/cache/348f9b1803aec24587aeff0440f55a9380b1e72c/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rails-diff --main --skip-bundle --force --skip-test --skip-system-test --quiet  --database=postgresql --javascript=esbuild --css=tailwind

[...]
```

Let me know if you need anything else and want me to tweak something! 🙌🏼 