### PR TITLE
Use `difftastic` for diffing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rails-diff (0.5.0)
-      diffy (~> 3.4)
+      difftastic (~> 0.7)
       rails (>= 7.0)
       thor (~> 1.0)
 
@@ -89,7 +89,12 @@ GEM
     crass (1.0.6)
     date (3.4.1)
     diff-lcs (1.5.1)
-    diffy (3.4.3)
+    difftastic (0.7.0)
+      pretty_please
+    difftastic (0.7.0-x86_64-darwin)
+      pretty_please
+    dispersion (0.2.0)
+      prism
     drb (2.2.1)
     erubi (1.13.1)
     globalid (1.2.1)
@@ -131,7 +136,10 @@ GEM
       racc (~> 1.4)
     pp (0.6.2)
       prettyprint
+    pretty_please (0.2.0)
+      dispersion (~> 0.2)
     prettyprint (0.2.0)
+    prism (1.4.0)
     psych (5.2.3)
       date
       stringio

--- a/lib/rails/diff.rb
+++ b/lib/rails/diff.rb
@@ -3,7 +3,7 @@
 require_relative "diff/version"
 require "rails"
 require "thor"
-require "diffy"
+require "difftastic"
 require "fileutils"
 require "open3"
 
@@ -148,12 +148,13 @@ module Rails
         return "File not found in the Rails template" unless File.exist?(rails_file)
         return "File not found in your repository" unless File.exist?(repo_file)
 
-        Diffy::Diff.new(
-          rails_file,
-          repo_file,
-          context: 2,
-          source: 'files'
-        ).to_s(:color).chomp
+        differ = Difftastic::Differ.new(
+          color: :always,
+          left_label: "Rails File (#{file})",
+          right_label: "Repo File (#{file})",
+        )
+
+        differ.diff_files(rails_file, repo_file).chomp
       end
 
       def cached_app?

--- a/rails-diff.gemspec
+++ b/rails-diff.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", ">= 7.0"
-  spec.add_dependency "diffy", "~> 3.4"
+  spec.add_dependency "difftastic", "~> 0.7"
   spec.add_dependency "thor", "~> 1.0"
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
This pull request replaces `diffy` with `difftastic` for a better diff output when comparing files.


|Before|After|
|---|---|
| ![CleanShot 2025-05-24 at 23 38 42@2x](https://github.com/user-attachments/assets/10a7d6d7-825d-484d-adb2-58b802df9267) | ![CleanShot 2025-05-24 at 23 39 23@2x](https://github.com/user-attachments/assets/0f7a2eda-ee24-4099-a6ba-2255de3fed2e) |


~~This still depends on this yet-to-be-released pull request: https://github.com/joeldrapper/difftastic-ruby/pull/30.~~
