### PR TITLE
Skip database adapter gems during bundle install

### DIFF
--- a/lib/rails/diff/rails_repo.rb
+++ b/lib/rails/diff/rails_repo.rb
@@ -31,7 +31,8 @@ module Rails
         within "railties" do
           unless Rails::Diff.system!("bundle check", abort: false, logger: logger)
             logger.info "Installing Rails dependencies"
-            Rails::Diff.system!("bundle", "install", "--without", "db", logger: logger)
+            Rails::Diff.system!("bundle", "config", "set", "--local", "without", "db", logger: logger)
+            Rails::Diff.system!("bundle", "install", logger: logger)
           end
         end
       end

--- a/lib/rails/diff/rails_repo.rb
+++ b/lib/rails/diff/rails_repo.rb
@@ -31,7 +31,7 @@ module Rails
         within "railties" do
           unless Rails::Diff.system!("bundle check", abort: false, logger: logger)
             logger.info "Installing Rails dependencies"
-            Rails::Diff.system!("bundle install", logger: logger)
+            Rails::Diff.system!("bundle", "install", "--without", "db", logger: logger)
           end
         end
       end

--- a/spec/lib/rails/diff/rails_repo_spec.rb
+++ b/spec/lib/rails/diff/rails_repo_spec.rb
@@ -97,18 +97,18 @@ RSpec.describe Rails::Diff::RailsRepo do
   end
 
   describe "#install_dependencies" do
-    it "runs bundle check and bundle install if needed, and logs appropriately" do
+    it "runs bundle check and bundle install with --without db if needed, and logs appropriately" do
       @git_repo.clone_at_commit(@git_repo.commits[0], rails_path)
       repo = described_class.new(logger:, cache_dir:, rails_repo: @git_repo.remote_repo)
 
       # Simulate bundle check failing, so bundle install is needed
       allow(Rails::Diff).to receive(:system!).with("bundle check", abort: false, logger: logger).and_return(false)
-      allow(Rails::Diff).to receive(:system!).with("bundle install", logger: logger).and_return(true)
+      allow(Rails::Diff).to receive(:system!).with("bundle", "install", "--without", "db", logger: logger).and_return(true)
 
       repo.install_dependencies
 
       expect(logger).to have_received(:info).with("Installing Rails dependencies")
-      expect(Rails::Diff).to have_received(:system!).with("bundle install", logger: logger)
+      expect(Rails::Diff).to have_received(:system!).with("bundle", "install", "--without", "db", logger: logger)
     end
 
     it "does not run bundle install if bundle check passes" do

--- a/spec/lib/rails/diff/rails_repo_spec.rb
+++ b/spec/lib/rails/diff/rails_repo_spec.rb
@@ -97,18 +97,20 @@ RSpec.describe Rails::Diff::RailsRepo do
   end
 
   describe "#install_dependencies" do
-    it "runs bundle check and bundle install with --without db if needed, and logs appropriately" do
+    it "runs bundle check and bundle install excluding db group if needed, and logs appropriately" do
       @git_repo.clone_at_commit(@git_repo.commits[0], rails_path)
       repo = described_class.new(logger:, cache_dir:, rails_repo: @git_repo.remote_repo)
 
       # Simulate bundle check failing, so bundle install is needed
       allow(Rails::Diff).to receive(:system!).with("bundle check", abort: false, logger: logger).and_return(false)
-      allow(Rails::Diff).to receive(:system!).with("bundle", "install", "--without", "db", logger: logger).and_return(true)
+      allow(Rails::Diff).to receive(:system!).with("bundle", "config", "set", "--local", "without", "db", logger: logger).and_return(true)
+      allow(Rails::Diff).to receive(:system!).with("bundle", "install", logger: logger).and_return(true)
 
       repo.install_dependencies
 
       expect(logger).to have_received(:info).with("Installing Rails dependencies")
-      expect(Rails::Diff).to have_received(:system!).with("bundle", "install", "--without", "db", logger: logger)
+      expect(Rails::Diff).to have_received(:system!).with("bundle", "config", "set", "--local", "without", "db", logger: logger)
+      expect(Rails::Diff).to have_received(:system!).with("bundle", "install", logger: logger)
     end
 
     it "does not run bundle install if bundle check passes" do


### PR DESCRIPTION
## Summary

- Add `--without db` flag to `bundle install` to skip database adapter gems (mysql2, pg, trilogy)
- Users without database client libraries installed on their system will no longer get build errors

Related to #24