### PR TITLE
Use `difftastic` for diffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Replace `diffy` with `difftastic` for better diff output with syntax highlighting.
+
 ## [0.6.0] - 2025-07-25
 
 - Add `--only` option to only include specific files or directories in the diff.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rails-diff (0.6.1)
-      diffy (~> 3.4)
+      difftastic (~> 0.8)
       rails (>= 7.0)
       thor (~> 1.0)
 
@@ -90,7 +90,12 @@ GEM
     crass (1.0.6)
     date (3.4.1)
     diff-lcs (1.5.1)
-    diffy (3.4.3)
+    difftastic (0.8.0)
+      pretty_please
+    difftastic (0.8.0-x86_64-darwin)
+      pretty_please
+    dispersion (0.2.0)
+      prism
     docile (1.4.1)
     drb (2.2.3)
     erubi (1.13.1)
@@ -140,6 +145,8 @@ GEM
       racc
     pp (0.6.2)
       prettyprint
+    pretty_please (0.2.0)
+      dispersion (~> 0.2)
     prettyprint (0.2.0)
     prism (1.4.0)
     psych (5.2.3)

--- a/lib/rails/diff.rb
+++ b/lib/rails/diff.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rails"
-require "diffy"
+require "difftastic"
 require "fileutils"
 require_relative "diff/cli"
 require_relative "diff/file_tracker"
@@ -52,12 +52,13 @@ module Rails
         return "File not found in the Rails template" unless File.exist?(rails_file)
         return "File not found in your repository" unless File.exist?(repo_file)
 
-        Diffy::Diff.new(
-          rails_file,
-          repo_file,
-          context: 2,
-          source: "files"
-        ).to_s(:color).chomp
+        differ = Difftastic::Differ.new(
+          color: :always,
+          left_label: "Rails File (#{file})",
+          right_label: "Repo File (#{file})"
+        )
+
+        differ.diff_files(rails_file, repo_file).chomp
       end
     end
   end

--- a/rails-diff.gemspec
+++ b/rails-diff.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", ">= 7.0"
-  spec.add_dependency "diffy", "~> 3.4"
+  spec.add_dependency "difftastic", "~> 0.8"
   spec.add_dependency "thor", "~> 1.0"
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
This pull request replaces `diffy` with `difftastic` for a better diff output when comparing files.


|Before|After|
|---|---|
| ![CleanShot 2025-05-24 at 23 38 42@2x](https://github.com/user-attachments/assets/10a7d6d7-825d-484d-adb2-58b802df9267) | ![CleanShot 2025-05-24 at 23 39 23@2x](https://github.com/user-attachments/assets/0f7a2eda-ee24-4099-a6ba-2255de3fed2e) |